### PR TITLE
GitHub Actions: Automatically update pre-commit hooks

### DIFF
--- a/.github/workflows/autoupdate-pre-commit.yaml
+++ b/.github/workflows/autoupdate-pre-commit.yaml
@@ -1,0 +1,31 @@
+name: Pre-commit auto-update
+
+on:
+  # every day at midnight
+  schedule:
+    - cron: "0 0 * * *"
+  # on demand
+  workflow_dispatch:
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🔁
+        uses: actions/checkout@v3
+
+      - name: Set up Python 🐍
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Pre-commit autoupdate
+        uses: browniebroke/pre-commit-autoupdate-action@main
+
+      - uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update/pre-commit-hooks
+          title: Update pre-commit hooks
+          commit-message: "chore: update pre-commit hooks"
+          body: Update versions of pre-commit hooks to latest version.


### PR DESCRIPTION
Add action to automatically update the pre-commit hooks in the repo. 
Runs every day at midnight. Creates a new PR if there are changes.
Fixes #11